### PR TITLE
chore: reduce number of cols in fuzzy matches

### DIFF
--- a/src/wadoh_raccoon/dataframe_matcher.py
+++ b/src/wadoh_raccoon/dataframe_matcher.py
@@ -224,7 +224,7 @@ class DataFrameMatcher:
             potential_matches
             .filter(pl.col(indicator).is_null())  # Keep only fields with ref_prep not joined
             .drop(indicator)  # Drop the temp indicator col
-            .select(fuzzy_with_demo.columns)  # Drop the previously joined null value cols
+            .select(fuzzy_with_demo.collect_schema().names())  # Drop the previously joined null value cols
         )
 
         # block/join based on dob

--- a/src/wadoh_raccoon/dataframe_matcher.py
+++ b/src/wadoh_raccoon/dataframe_matcher.py
@@ -167,7 +167,6 @@ class DataFrameMatcher:
             )
         )
 
-
         return ref_prep, submissions_to_fuzzy_prep
 
     def filter_demo(self, submissions_to_fuzzy_prep):
@@ -225,6 +224,7 @@ class DataFrameMatcher:
             potential_matches
             .filter(pl.col(indicator).is_null())  # Keep only fields with ref_prep not joined
             .drop(indicator)  # Drop the temp indicator col
+            .select(fuzzy_with_demo.columns)  # Drop the previously joined null value cols
         )
 
         # block/join based on dob


### PR DESCRIPTION
## 📑 Description
Drop cols before second join to same data frame

Drop the joined columns in the df that only contains rows where the left had no matches on the right (essentially an anti/outer join). The reduces the number of duplicate cols with suffixes as this df gets joined to the same data with different keys in the next block.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## How to Test

<!--
Please describe the steps to test your changes. Include any relevant testing instructions or guidelines.
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
-   [ ] I have **reviewed** the pull request for any sensitive data, including text and images.
-   [ ] I have read and followed the contributing guidelines.
-   [ ] I have checked my code for any issues.
-   [ ] I have updated the documentation (if applicable).
-   [ ] I have added tests to cover my changes (if applicable).
-   [ ] All tests are passing (if applicable).
-   [ ] My changes do not introduce any new warnings.
-   [ ] I have run the code locally and verified the changes work as expected.

## Screenshots (if applicable)

<!--
If your pull request includes images or screenshots, **please confirm** that no sensitive information is present. If unsure, remove or blur any potentially sensitive content.
-->
