### PR TITLE
Rename fuzzy matched

### DIFF
--- a/src/wadoh_raccoon/dataframe_matcher.py
+++ b/src/wadoh_raccoon/dataframe_matcher.py
@@ -377,9 +377,6 @@ class DataFrameMatcher:
                 .group_by(pl.col(self.key))
                 .agg(pl.all().sort_by('business_day_count').first())
             )
-        
-        if fuzzy_matched.height==0:
-            fuzzy_matched = pl.DataFrame()
 
         return fuzzy_matched, fuzzy_unmatched
 


### PR DESCRIPTION
Closes #38

## 📑 Description
- **Split fuzzy_match into fuzzy_match + score methods (simplifies the fuzzy_match method a bit and places the scoring logic in a distinct method)**
- Rename fuzzy_review to fuzzy_matched
- Remove original "fuzzy_matched" object output from `fuzzy_match()` (this was just a duplicate of exact_match, no transformations are done to it during fuzzy_match())
- Remove exact_match as a param for `fuzzy_match()` (see above)
- Remove original fuzzy_matched (duplicate of exact_match) from `fuzzZ()` output
## How to Test

<!--
Please describe the steps to test your changes. Include any relevant testing instructions or guidelines.
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
-   [ ] I have **reviewed** the pull request for any sensitive data, including text and images.
-   [ ] I have read and followed the contributing guidelines.
-   [ ] I have checked my code for any issues.
-   [ ] I have updated the documentation (if applicable).
-   [ ] I have added tests to cover my changes (if applicable).
-   [ ] All tests are passing (if applicable).
-   [ ] My changes do not introduce any new warnings.
-   [ ] I have run the code locally and verified the changes work as expected.

## Screenshots (if applicable)

<!--
If your pull request includes images or screenshots, **please confirm** that no sensitive information is present. If unsure, remove or blur any potentially sensitive content.
-->
