### PR TITLE
chore: add publish to pypi in gh action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-tests  # This makes sure the build job runs first
 
+    outputs:
+      released: ${{ steps.changelog.outputs.skipped == 'false' }}
+
     steps:
       # Checkout the code
       - uses: actions/checkout@v4
@@ -78,6 +81,13 @@ jobs:
           TAG: ${{ steps.changelog.outputs.tag }}
           CHANGELOG: ${{ steps.changelog.outputs.clean_changelog }}
           FILES: dist/*.tar.gz dist/*.whl
+
+      - name: Upload dist artifacts
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: dist
+          path: dist/
           
       - name: Push Files for GitHub Action
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
@@ -90,3 +100,42 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  publish:
+    name: publish to pypi
+    needs: build-and-release
+    if: >
+      needs.build-and-release.result == 'success' &&
+      needs.build-and-release.outputs.released == 'true'
+
+    runs-on: ubuntu-latest
+
+    environment: 
+      name: pypi-env
+
+    permissions: 
+      id-token: write
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Set up Python
+      run: uv python install 3.13
+
+    - name: Download dist artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: dist
+        path: dist
+
+    - name: Smoke test (wheel)
+      run: uv run --isolated --no-project --with dist/*.whl tests/smoke_test.py
+
+    - name: Smoke test (source distribution)
+      run: uv run --isolated --no-project --with dist/*.tar.gz tests/smoke_test.py
+
+    - name: Publish
+      run: uv publish

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -1,0 +1,24 @@
+"""Check that basic features work before publishing to pypi.
+
+Catch cases where e.g. files are missing so the import doesn't work. It is
+recommended to check that e.g. assets are included."""
+
+# tests/smoke_test.py
+import sys
+
+import wadoh_raccoon  # replace with your actual package name
+from wadoh_raccoon.utils import helpers
+
+def test_basic_import():
+    """Check that the package can be imported."""
+    assert wadoh_raccoon is not None
+
+def test_basic_functionality():
+    """Optionally check one key function."""
+    result = helpers.clean_name(col="test")
+    assert result is not None
+
+if __name__ == "__main__":
+    test_basic_import()
+    test_basic_functionality()
+    print("Smoke test passed!")


### PR DESCRIPTION
## details

- adds publish to pypi step in `release.yml`
- adds `smoke_test.py` which runs to test if the package files work before publishing

## confirmation

- I followed [this guide from uv](https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi) to publish it
- In the settings of this repo I went to `Environments` and set up an environment called `pypi-env`. This is used by the github action and pypi to confirm the projects are linked without using credentials
- I set up a project in pypi called `wadoh_raccoon` that is linked to this repo
- Everything was tested [in this test repo](https://github.com/coe-test-org/test_project) and the resulting [pypi package called water-bottle-please](https://pypi.org/project/water-bottle-please/) was successfully published

## testing manually

You can run the following to test it out:

- go to the root of the repo and run `uv build`. it will make `.whl` and `.tar.gz` files
- run `uv run --isolated --no-project --with dist/path/to/.whl/or/tar.gz tests/smoke_test.py`
